### PR TITLE
Add AppLogLevel wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 </p>
 
 # AppLogger
-Wrapper around Apple's new Swift logging APIs, particularly [Logger](https://developer.apple.com/documentation/os/logger).
+Wrapper around Apple's Swift unified logging APIs, particularly [Logger](https://developer.apple.com/documentation/os/logger).
 
-Provides a basic `public`/`private` logging functionality at a given level (e.g. `debug` (default)).
+Provides `public` and `private` logging with an app-facing `AppLogLevel` abstraction, so clients do not need to import `os` to choose a log level. The default level is `.default`, which maps to `OSLogType.default` and shows up in Console.app without requiring debug filtering.
 
 For more information, please refer to this WWDC20 video: [Explore logging in Swift](https://developer.apple.com/wwdc20/10168)
 
@@ -27,14 +27,16 @@ For more information, please refer to this WWDC20 video: [Explore logging in Swi
 ```swift
 import AppLogger
 
-// Create an instance of the "AppLogger with default options.
-let logger = AppLogger()
+let logger = AppLogger(subsystem: "com.example.app", category: "network")
 
 // Log public information.
-logger.log("iPhone screen size: \(screenSize)")
+logger.log("Request started")
 
 // Log private information.
-logger.log("Username: \(username); Password: \(password)", isPrivate: true)
+logger.log(level: .info, "Request headers: \(headers)", isPrivate: true)
+
+// Set custom levels.
+logger.log(level: .error, "Request failed: \(error.localizedDescription)")
 ```
 
 ### Defaults
@@ -43,6 +45,18 @@ public struct Defaults {
     public static let subsystem = Bundle.main.bundleIdentifier ?? "AppLogger"
     public static let category = "default"
     public static let isPrivate = false
+    public static let level: AppLogLevel = .default
+}
+```
+
+### AppLogLevel
+```swift
+public enum AppLogLevel {
+    case debug
+    case info
+    case `default`
+    case error
+    case fault
 }
 ```
 
@@ -52,7 +66,7 @@ public struct Defaults {
 ![Xcode Sample](https://i.imgur.com/6TNaUQo.png)
 
 #### macOS Console app
-⚠️ Make sure you have enabled `Action / Include Info/Debug Messages` in the **Console app** in order to see `debug messages` from your app.
+`.default`, `.error`, and `.fault` logs are shown by default in the **Console app**. If you emit `debug` logs, enable `Action / Include Info/Debug Messages` to display them.
 
 ![Console App](https://i.imgur.com/XBGOpLP.png)
 

--- a/Sources/AppLogger/AppLogLevel.swift
+++ b/Sources/AppLogger/AppLogLevel.swift
@@ -1,0 +1,25 @@
+import os
+
+/// Represents the supported logging levels exposed by ``AppLogger``.
+public enum AppLogLevel: Sendable {
+    case debug
+    case `default`
+    case error
+    case fault
+    case info
+
+    var osLogType: OSLogType {
+        switch self {
+        case .info:
+            return .info
+        case .default:
+            return .default
+        case .debug:
+            return .debug
+        case .error:
+            return .error
+        case .fault:
+            return .fault
+        }
+    }
+}

--- a/Sources/AppLogger/AppLogger.swift
+++ b/Sources/AppLogger/AppLogger.swift
@@ -1,10 +1,3 @@
-//
-//  AppLogger.swift
-//  AppLogger
-//
-//  Created by Fernando Fernandes on 29.06.20.
-//
-
 import Foundation
 import os
 
@@ -24,6 +17,7 @@ public struct AppLogger {
         public static let subsystem = Bundle.main.bundleIdentifier ?? "AppLogger"
         public static let category = "default"
         public static let isPrivate = false
+        public static let level: AppLogLevel = .default
     }
 
     // MARK: - Private Properties
@@ -52,21 +46,16 @@ public extension AppLogger {
     
     /// Logs a string interpolation at the given level.
     ///
-    /// Notice that `.debug` won't work with simulators (nothing is shown in the Console app for this level),
-    /// but works fine with physical devices. This is a known issue:
-    /// https://stackoverflow.com/a/58814535/584548
-    ///
     /// - Parameters:
-    ///   - level: `OSLogType`; default is `.debug`.
+    ///   - level: `AppLogLevel`; default is `.default`.
     ///   - message: The `String` to be logged.
     ///   - isPrivate: Sets the `OSLogPrivacy` to be used by the function. `true` means `.private`;
     ///   `false` means `.public`. The default is `false`.
-    func log(level: OSLogType = .debug, _ message: String, isPrivate: Bool = Defaults.isPrivate) {
+    func log(level: AppLogLevel = Defaults.level, _ message: String, isPrivate: Bool = Defaults.isPrivate) {
         if isPrivate {
-            logger.log(level: level, "\(message, privacy: .private)")
+            logger.log(level: level.osLogType, "\(message, privacy: .private)")
         } else {
-            logger.log(level: level, "\(message, privacy: .public)")
+            logger.log(level: level.osLogType, "\(message, privacy: .public)")
         }
     }
 }
-

--- a/Tests/AppLoggerTests/AppLoggerTests.swift
+++ b/Tests/AppLoggerTests/AppLoggerTests.swift
@@ -2,9 +2,15 @@ import XCTest
 @testable import AppLogger
 
 final class AppLoggerTests: XCTestCase {
-    func empty() {}
+    func testDefaultLevelIsDefault() {
+        XCTAssertEqual(AppLogger.Defaults.level, .default)
+    }
 
-    static let allTests = [
-        ("empty", empty),
-    ]
+    func testAppLogLevelMapping() {
+        XCTAssertEqual(AppLogLevel.debug.osLogType, .debug)
+        XCTAssertEqual(AppLogLevel.info.osLogType, .info)
+        XCTAssertEqual(AppLogLevel.default.osLogType, .default)
+        XCTAssertEqual(AppLogLevel.error.osLogType, .error)
+        XCTAssertEqual(AppLogLevel.fault.osLogType, .fault)
+    }
 }


### PR DESCRIPTION
## Summary
- add `AppLogLevel` so package clients can choose log levels without importing `os`
- change `AppLogger` to default to `.default` so logs are visible in Console.app by default
- update tests and README examples for the new API

## Testing
- `swift test`